### PR TITLE
simplify cloud-init wait

### DIFF
--- a/ubuntu-22.04/ubuntu.json
+++ b/ubuntu-22.04/ubuntu.json
@@ -40,7 +40,7 @@
   "provisioners": [{
     "type": "shell",
     "inline": [
-      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done"
+      "cloud-init status --wait"
     ]
   }]
 }


### PR DESCRIPTION
IMHO it is better to use cloud-init --wait https://ubuntu.com/blog/cloud-init-v-18-2-cli-subcommands